### PR TITLE
Update thirdparty/configure-native-deps.sh

### DIFF
--- a/thirdparty/configure-native-deps.sh
+++ b/thirdparty/configure-native-deps.sh
@@ -6,7 +6,7 @@
 # Copy-paste the entire script into http://shellcheck.net to check.
 ####
 
-locations="/lib /lib64 /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib/arm-linux-gnueabihf/ /usr/lib/mipsel-linux-gnu /usr/local/lib /opt/lib /opt/local/lib /app/lib"
+locations="/lib /lib64 /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib/arm-linux-gnueabihf /usr/lib/aarch64-linux-gnu /usr/lib/powerpc64le-linux-gnu /usr/lib/mipsel-linux-gnu /usr/local/lib /opt/lib /opt/local/lib /app/lib"
 sonames="liblua.so.5.1.5 liblua5.1.so.5.1 liblua5.1.so.0 liblua.so.5.1 liblua-5.1.so liblua5.1.so"
 
 if [ -f Eluant.dll.config ]; then


### PR DESCRIPTION
Add aarch64 and ppc64le architecture library to search paths.

This should allow the snap package that I maintain to be buildable on those platforms.